### PR TITLE
Add trade P&L tracking

### DIFF
--- a/backend/features/ai_brain.py
+++ b/backend/features/ai_brain.py
@@ -1,7 +1,6 @@
 import requests
 import os
 import sys
-import os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from utils.memory import MemoryManager
 

--- a/backend/features/autotrade.py
+++ b/backend/features/autotrade.py
@@ -1,3 +1,19 @@
+from utils.memory import MemoryManager
+
+memory = MemoryManager()
+memory.load()
+
+
+def record_sell(
+    ticker: str, buy_price: float, sell_price: float, quantity: float
+) -> None:
+    """Record the result of a completed trade and log the outcome."""
+    pnl = memory.record_trade(ticker, buy_price, sell_price, quantity)
+    total = memory.memory[ticker]["total_profit"]
+    msg = f"\U0001f4ca {ticker} trade result: {pnl:+.2f} | Total P/L: {total:.2f}"
+    print(msg)
+    # Placeholder for Telegram integration
+
 
 def run_autotrader():
     print("Running auto-trading logic...")

--- a/backend/utils/memory.py
+++ b/backend/utils/memory.py
@@ -15,3 +15,12 @@ class MemoryManager:
     def save(self):
         with open(self.path, 'w') as f:
             json.dump(self.memory, f, indent=4)
+
+    def record_trade(self, ticker: str, buy_price: float, sell_price: float, quantity: float) -> float:
+        """Update profit/loss for a completed trade and persist it."""
+        pnl = (sell_price - buy_price) * quantity
+        data = self.memory.setdefault(ticker, {"total_profit": 0.0, "trade_count": 0})
+        data["total_profit"] += pnl
+        data["trade_count"] += 1
+        self.save()
+        return pnl

--- a/data/memory.json
+++ b/data/memory.json
@@ -1,2 +1,1 @@
-mkdir data
-echo {} > data/memory.json
+{}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+black==25.1.0
+click==8.2.1
+iniconfig==2.1.0
+isort==6.0.1
+mypy==1.15.0
+mypy_extensions==1.1.0
+nodeenv==1.9.1
+packaging==25.0
+pathspec==0.12.1
+platformdirs==4.3.8
+pluggy==1.6.0
+pyright==1.1.401
+pytest==8.3.5
+ruff==0.11.10
+typing_extensions==4.13.2


### PR DESCRIPTION
## Summary
- fix double import in `ai_brain`
- add `MemoryManager.record_trade` for updating P&L
- track profits from sells in `autotrade`
- initialize empty `memory.json`
- add development requirements

## Testing
- `pytest -q`
- `ruff check .`
- `black --check .`
- `isort --check .`
- `pyright`
- `mypy .`

------
https://chatgpt.com/codex/tasks/task_e_685250bf402c832b87d95946b33f72bf