### PR TITLE
Implement self-learning features and terminal dashboard

### DIFF
--- a/backend/features/ai_brain.py
+++ b/backend/features/ai_brain.py
@@ -3,6 +3,8 @@ import os
 import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from utils.memory import MemoryManager
+from .qa_memory import QAMemory
+from .evaluator import Evaluator
 
 openai = None
 
@@ -10,6 +12,8 @@ class AIBrain:
     def __init__(self, model="gpt-3.5-turbo"):
         self.model = model
         self.memory = MemoryManager()
+        self.qa_memory = QAMemory()
+        self.evaluator = Evaluator()
         self.api_key = os.getenv("OPENAI_API_KEY")
         if self.api_key:
             import openai as openai_lib
@@ -39,5 +43,8 @@ class AIBrain:
 
         self.memory.memory["last_answer"] = answer
         self.memory.save()
+        score = self.evaluator.score(prompt, answer, "Ollama")
+        self.qa_memory.add(prompt, answer, "Ollama", score)
+        self.evaluator.update_leaderboard(prompt, score)
         return answer
 

--- a/backend/features/dashboard.py
+++ b/backend/features/dashboard.py
@@ -1,0 +1,48 @@
+import curses
+import threading
+import time
+
+from .qa_memory import QAMemory
+
+
+class TerminalDashboard(threading.Thread):
+    def __init__(self, refresh: int = 2):
+        super().__init__(daemon=True)
+        self.refresh = refresh
+        self.stop_event = threading.Event()
+        self.paused = False
+        self.memory = QAMemory()
+        self.success = 0
+        self.fail = 0
+
+    def run(self):
+        try:
+            curses.wrapper(self.loop)
+        except Exception:
+            pass
+
+    def loop(self, stdscr):
+        stdscr.nodelay(True)
+        while not self.stop_event.is_set():
+            stdscr.clear()
+            stdscr.addstr(0, 0, f"Q&A stored: {len(self.memory.data)}")
+            stdscr.addstr(1, 0, f"Success: {self.success}  Fail: {self.fail}")
+            stdscr.addstr(3, 0, "Commands: [p]ause/[r]esume [c]lear [q]uit")
+            stdscr.refresh()
+            ch = stdscr.getch()
+            if ch != -1:
+                ch = chr(ch)
+                if ch == "p":
+                    self.paused = True
+                elif ch == "r":
+                    self.paused = False
+                elif ch == "c":
+                    self.memory.data = []
+                    self.memory.save()
+                elif ch == "q":
+                    self.stop_event.set()
+                    break
+            time.sleep(self.refresh)
+
+    def stop(self):
+        self.stop_event.set()

--- a/backend/features/evaluator.py
+++ b/backend/features/evaluator.py
@@ -1,0 +1,39 @@
+import csv
+import math
+from pathlib import Path
+
+
+SOURCE_WEIGHT = {
+    "DuckDuckGo": 1.0,
+    "Bing": 0.8,
+    "Ollama": 0.5,
+}
+
+
+class Evaluator:
+    def __init__(self, leaderboard: str = "data/leaderboard.csv"):
+        self.board_path = Path(leaderboard)
+        if not self.board_path.exists():
+            self.board_path.write_text("question,score\n")
+
+    def score(self, question: str, answer: str, source: str) -> float:
+        tokens = len(answer.split())
+        token_score = min(tokens / 100, 1.0)
+        keywords = set(question.lower().split())
+        overlap = sum(1 for w in answer.lower().split() if w in keywords)
+        keyword_score = overlap / (len(keywords) or 1)
+        source_score = SOURCE_WEIGHT.get(source, 0.5)
+        return round((token_score * 0.5) + (keyword_score * 0.3) + (source_score * 0.2), 4)
+
+    def update_leaderboard(self, question: str, score: float):
+        entries = []
+        if self.board_path.exists():
+            with open(self.board_path, newline="") as f:
+                reader = csv.DictReader(f)
+                entries = list(reader)
+        entries.append({"question": question, "score": score})
+        entries.sort(key=lambda x: float(x["score"]), reverse=True)
+        with open(self.board_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=["question", "score"])
+            writer.writeheader()
+            writer.writerows(entries[:100])

--- a/backend/features/qa_memory.py
+++ b/backend/features/qa_memory.py
@@ -1,0 +1,80 @@
+import json
+import time
+from pathlib import Path
+from difflib import SequenceMatcher
+
+
+class QAMemory:
+    def __init__(self, path: str = "data/qa_memory.json"):
+        self.path = Path(path)
+        self.data = []
+        self.load()
+
+    def load(self):
+        if self.path.exists():
+            try:
+                with open(self.path) as f:
+                    self.data = json.load(f)
+            except Exception:
+                self.data = []
+        self.prune()
+
+    def save(self):
+        self.path.parent.mkdir(exist_ok=True)
+        with open(self.path, "w") as f:
+            json.dump(self.data, f, indent=2)
+
+    def _is_duplicate(self, prompt: str) -> bool:
+        for entry in self.data:
+            if entry.get("question") == prompt:
+                return True
+        return False
+
+    def add(self, question: str, answer: str, source: str, confidence: float):
+        tokens = len(answer.split())
+        if tokens < 20:
+            return
+        if confidence < 0.5 and self._is_duplicate(question):
+            return
+        entry = {
+            "question": question,
+            "answer": answer,
+            "source": source,
+            "tokens": tokens,
+            "confidence": confidence,
+            "timestamp": time.time(),
+        }
+        self._replace_outdated(entry)
+        if not self._is_duplicate(question):
+            self.data.append(entry)
+        self.save()
+
+    def _replace_outdated(self, new_entry: dict):
+        year_tokens = [t for t in new_entry["answer"].split() if t.isdigit() and len(t) == 4]
+        if not year_tokens:
+            return
+        latest_year = max(map(int, year_tokens))
+        for idx, entry in enumerate(list(self.data)):
+            old_years = [t for t in entry["answer"].split() if t.isdigit() and len(t) == 4]
+            if old_years and max(map(int, old_years)) < latest_year:
+                if SequenceMatcher(None, entry["question"], new_entry["question"]).ratio() > 0.6:
+                    self.data[idx] = new_entry
+
+    def prune(self):
+        seen = set()
+        pruned = []
+        for entry in sorted(self.data, key=lambda e: e.get("timestamp", 0)):
+            key = entry["question"]
+            if key in seen:
+                continue
+            seen.add(key)
+            if entry.get("tokens", 0) >= 20:
+                pruned.append(entry)
+        self.data = pruned
+        self.save()
+
+    def get_random(self):
+        if not self.data:
+            return None
+        import random
+        return random.choice(self.data)

--- a/backend/features/self_reflect.py
+++ b/backend/features/self_reflect.py
@@ -1,0 +1,37 @@
+import threading
+import time
+
+from .ai_brain import AIBrain
+from .qa_memory import QAMemory
+from .evaluator import Evaluator
+
+
+class SelfReflection(threading.Thread):
+    def __init__(self, interval: int = 300):
+        super().__init__(daemon=True)
+        self.interval = interval
+        self.stop_event = threading.Event()
+        self.brain = AIBrain()
+        self.memory = QAMemory()
+        self.evaluator = Evaluator()
+
+    def run(self):
+        while not self.stop_event.is_set():
+            entry = self.memory.get_random()
+            if entry:
+                new_answer = self.brain.ask(entry["question"])
+                score_old = self.evaluator.score(
+                    entry["question"], entry["answer"], entry["source"]
+                )
+                score_new = self.evaluator.score(
+                    entry["question"], new_answer, entry["source"]
+                )
+                if score_new > score_old:
+                    self.memory.add(
+                        entry["question"], new_answer, entry["source"], score_new
+                    )
+                    self.evaluator.update_leaderboard(entry["question"], score_new)
+            time.sleep(self.interval)
+
+    def stop(self):
+        self.stop_event.set()

--- a/backend/features/trending.py
+++ b/backend/features/trending.py
@@ -1,0 +1,66 @@
+import random
+import time
+from pathlib import Path
+from typing import List
+
+import feedparser
+
+RSS_FEEDS = [
+    "https://feeds.bbci.co.uk/news/rss.xml",
+    "https://feeds.reuters.com/reuters/topNews",
+    "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
+]
+
+
+class TrendingTopics:
+    def __init__(self, cache_file: str = "data/trending.json"):
+        self.cache = Path(cache_file)
+        self.topics: List[str] = []
+        self.last_fetch = 0
+        self.load()
+
+    def load(self):
+        if self.cache.exists():
+            try:
+                import json
+                data = json.loads(self.cache.read_text())
+                self.topics = data.get("topics", [])
+                self.last_fetch = data.get("timestamp", 0)
+            except Exception:
+                pass
+
+    def save(self):
+        self.cache.parent.mkdir(exist_ok=True)
+        import json
+        self.cache.write_text(
+            json.dumps({"topics": self.topics, "timestamp": self.last_fetch}, indent=2)
+        )
+
+    def fetch(self):
+        if time.time() - self.last_fetch < 24 * 3600 and self.topics:
+            return self.topics
+        topics = []
+        for url in RSS_FEEDS:
+            try:
+                feed = feedparser.parse(url)
+                for entry in feed.entries[:5]:
+                    topics.append(entry.title)
+            except Exception:
+                continue
+        if topics:
+            self.topics = topics[:20]
+            self.last_fetch = time.time()
+            self.save()
+        return self.topics
+
+    def random_topic(self) -> str:
+        topics = self.fetch()
+        if not topics:
+            return random.choice([
+                "technology",
+                "science",
+                "finance",
+                "sports",
+                "culture",
+            ])
+        return random.choice(topics)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,8 @@
 from features.ai_brain import AIBrain
 from features.web_search import web_search
 from features.autotrade import run_autotrader
+from features.self_reflect import SelfReflection
+from features.dashboard import TerminalDashboard
 
 import subprocess
 import threading
@@ -65,6 +67,10 @@ def main():
         target=monitor_autotrain, args=(stop_event,), daemon=True
     )
     monitor_thread.start()
+    reflect_thread = SelfReflection()
+    dashboard_thread = TerminalDashboard()
+    reflect_thread.start()
+    dashboard_thread.start()
 
     try:
         while True:
@@ -82,10 +88,18 @@ def main():
                 response = "Trade executed"
             else:
                 response = brain.ask(prompt)
-
+            
+            if response.startswith("[Error"):
+                dashboard_thread.fail += 1
+            else:
+                dashboard_thread.success += 1
             print(f"🤖 JARVIS: {response}")
     except KeyboardInterrupt:
         print("\n👋 JARVIS shutting down.")
     finally:
         stop_event.set()
+        reflect_thread.stop()
+        dashboard_thread.stop()
         monitor_thread.join()
+        reflect_thread.join()
+        dashboard_thread.join()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ streamlit
 flask
 python-dotenv
 pandas
+feedparser


### PR DESCRIPTION
## Summary
- add Q&A memory manager with pruning and outdated knowledge replacement
- implement evaluator scoring system and trending topic fetcher
- update AI brain to store answers in memory and leaderboard
- extend synthetic trainer with trending questions and memory retention
- add self reflection background thread and terminal dashboard
- wire dashboard and reflection into main process
- include feedparser dependency

## Testing
- `python -m py_compile backend/features/qa_memory.py backend/features/evaluator.py backend/features/trending.py backend/features/self_reflect.py backend/features/dashboard.py backend/main.py autotrain.py`
- `python -m py_compile backend/features/autotrade.py`


------
https://chatgpt.com/codex/tasks/task_e_6853a32d532c832bae18f07197734cf9