### PR TITLE
Add auto-evaluator and dashboard metrics

### DIFF
--- a/backend/features/dashboard.py
+++ b/backend/features/dashboard.py
@@ -12,8 +12,7 @@ class TerminalDashboard(threading.Thread):
         self.stop_event = threading.Event()
         self.paused = False
         self.memory = QAMemory()
-        self.success = 0
-        self.fail = 0
+        self.start_time = time.time()
 
     def run(self):
         try:
@@ -25,9 +24,27 @@ class TerminalDashboard(threading.Thread):
         stdscr.nodelay(True)
         while not self.stop_event.is_set():
             stdscr.clear()
-            stdscr.addstr(0, 0, f"Q&A stored: {len(self.memory.data)}")
-            stdscr.addstr(1, 0, f"Success: {self.success}  Fail: {self.fail}")
-            stdscr.addstr(3, 0, "Commands: [p]ause/[r]esume [c]lear [q]uit")
+            self.memory.load()
+            total = len(self.memory.data)
+            tokens = sum(e.get("tokens", 0) for e in self.memory.data)
+            avg_conf = (
+                sum(e.get("confidence", 0) for e in self.memory.data) / total
+                if total
+                else 0
+            )
+            unique_q = {e["question"] for e in self.memory.data}
+            dup_rate = 1 - (len(unique_q) / total) if total else 0
+            learning_rate = total / ((time.time() - self.start_time) / 60 + 1e-6)
+            active = self.memory.data[-1]["source"] if self.memory.data else "N/A"
+
+            stdscr.addstr(0, 0, f"Q&A stored: {total}")
+            stdscr.addstr(1, 0, f"Avg confidence: {avg_conf:.2f}")
+            stdscr.addstr(2, 0, f"Learning rate: {learning_rate:.2f}/min")
+            stdscr.addstr(3, 0, f"Token usage: {tokens}")
+            stdscr.addstr(4, 0, f"Duplicate rate: {dup_rate:.2f}")
+            stdscr.addstr(5, 0, f"Pruned: {self.memory.pruned_total}")
+            stdscr.addstr(6, 0, f"Active source: {active}")
+            stdscr.addstr(8, 0, "Commands: [p]ause/[r]esume [c]lear [q]uit")
             stdscr.refresh()
             ch = stdscr.getch()
             if ch != -1:


### PR DESCRIPTION
## Summary
- refine AIBrain answers when scoring poorly by adding web search context
- expand Evaluator with originality checks against stored answers
- prune QA memory with duplicate and low-token removal
- show confidence, token usage and other stats in terminal dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853a667040c832b8e5b50d7dbf0c73b