### PR TITLE
Add nightly self-audit loop

### DIFF
--- a/backend/features/dashboard.py
+++ b/backend/features/dashboard.py
@@ -32,6 +32,13 @@ class TerminalDashboard(threading.Thread):
                 if total
                 else 0
             )
+            now = time.time()
+            review = [
+                e
+                for e in self.memory.data
+                if now - e.get("timestamp", 0) > 7 * 86400
+                or e.get("confidence", 1) < 0.5
+            ]
             unique_q = {e["question"] for e in self.memory.data}
             dup_rate = 1 - (len(unique_q) / total) if total else 0
             learning_rate = total / ((time.time() - self.start_time) / 60 + 1e-6)
@@ -43,8 +50,9 @@ class TerminalDashboard(threading.Thread):
             stdscr.addstr(3, 0, f"Token usage: {tokens}")
             stdscr.addstr(4, 0, f"Duplicate rate: {dup_rate:.2f}")
             stdscr.addstr(5, 0, f"Pruned: {self.memory.pruned_total}")
-            stdscr.addstr(6, 0, f"Active source: {active}")
-            stdscr.addstr(8, 0, "Commands: [p]ause/[r]esume [c]lear [q]uit")
+            stdscr.addstr(6, 0, f"Needs review: {len(review)}")
+            stdscr.addstr(7, 0, f"Active source: {active}")
+            stdscr.addstr(9, 0, "Commands: [p]ause/[r]esume [c]lear [q]uit")
             stdscr.refresh()
             ch = stdscr.getch()
             if ch != -1:

--- a/backend/features/self_audit.py
+++ b/backend/features/self_audit.py
@@ -1,0 +1,62 @@
+import threading
+import time
+
+from .ai_brain import AIBrain
+from .qa_memory import QAMemory
+from .evaluator import Evaluator
+from .web_search import web_search
+
+
+class SelfAudit(threading.Thread):
+    """Nightly audit that re-checks all stored Q&A."""
+
+    def __init__(self, interval: int = 24 * 3600, review_days: int = 7):
+        super().__init__(daemon=True)
+        self.interval = interval
+        self.review_age = review_days * 86400
+        self.stop_event = threading.Event()
+        self.brain = AIBrain()
+        self.memory = QAMemory()
+        self.evaluator = Evaluator()
+
+    def stop(self) -> None:
+        self.stop_event.set()
+
+    def run(self) -> None:
+        while not self.stop_event.is_set():
+            self.audit()
+            self.stop_event.wait(self.interval)
+
+    def audit(self) -> None:
+        """Evaluate all memory entries and refresh low-quality answers."""
+        self.memory.load()
+        now = time.time()
+        changed = False
+        for i, entry in enumerate(list(self.memory.data)):
+            score = entry.get("confidence")
+            if score is None:
+                score = self.evaluator.score(entry["question"], entry["answer"], entry["source"])
+            age = now - entry.get("timestamp", 0)
+            if age < self.review_age and score >= 0.5:
+                continue
+
+            try:
+                context = web_search(entry["question"])
+            except Exception:
+                context = ""
+            prompt = f"{entry['question']}\n\nContext:\n{context}"
+            new_answer = self.brain.ask(prompt)
+            new_score = self.evaluator.score(entry["question"], new_answer, "Ollama")
+            if new_score > score:
+                self.memory.data[i] = {
+                    "question": entry["question"],
+                    "answer": new_answer,
+                    "source": "Ollama",
+                    "tokens": len(new_answer.split()),
+                    "confidence": new_score,
+                    "timestamp": time.time(),
+                }
+                self.evaluator.update_leaderboard(entry["question"], new_score)
+                changed = True
+        if changed:
+            self.memory.save()

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from features.ai_brain import AIBrain
 from features.web_search import web_search
 from features.autotrade import run_autotrader
 from features.self_reflect import SelfReflection
+from features.self_audit import SelfAudit
 from features.dashboard import TerminalDashboard
 
 import subprocess
@@ -68,8 +69,10 @@ def main():
     )
     monitor_thread.start()
     reflect_thread = SelfReflection()
+    audit_thread = SelfAudit()
     dashboard_thread = TerminalDashboard()
     reflect_thread.start()
+    audit_thread.start()
     dashboard_thread.start()
 
     try:
@@ -99,7 +102,9 @@ def main():
     finally:
         stop_event.set()
         reflect_thread.stop()
+        audit_thread.stop()
         dashboard_thread.stop()
         monitor_thread.join()
         reflect_thread.join()
+        audit_thread.join()
         dashboard_thread.join()


### PR DESCRIPTION
## Summary
- add nightly audit of QA memory using Ollama & web search
- show count of entries needing review in the dashboard
- run the self-audit thread in the main application

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853a7f16238832bb031acc0b96ee2f1