### PR TITLE
Add dashboard keyboard controls and pause file

### DIFF
--- a/autotrain.py
+++ b/autotrain.py
@@ -5,6 +5,8 @@ import random
 import time
 from pathlib import Path
 
+PAUSE_FILE = Path("autotrain.pause")
+
 from backend.features.ai_brain import AIBrain
 from backend.features.web_search import web_search
 from backend.features.trending import TrendingTopics
@@ -102,6 +104,9 @@ class SyntheticTrainer:
     def run(self):
         counter = len(self.seen)
         while True:
+            if PAUSE_FILE.exists():
+                time.sleep(1)
+                continue
             question = self.generate_question()
             qhash = hashlib.sha1(question.encode()).hexdigest()
             if qhash in self.seen:

--- a/backend/features/dashboard.py
+++ b/backend/features/dashboard.py
@@ -1,8 +1,11 @@
 import curses
+import json
 import threading
 import time
+from pathlib import Path
 
 from .qa_memory import QAMemory
+from .web_search import web_search
 
 
 class TerminalDashboard(threading.Thread):
@@ -11,6 +14,10 @@ class TerminalDashboard(threading.Thread):
         self.refresh = refresh
         self.stop_event = threading.Event()
         self.paused = False
+        self.paused_since: float | None = None
+        self.paused_total = 0.0
+        self.log_msg = ""
+        self.flash_until = 0.0
         self.memory = QAMemory()
         self.start_time = time.time()
         self.audit = audit
@@ -24,6 +31,39 @@ class TerminalDashboard(threading.Thread):
         if len(self.interactions) > 5:
             self.interactions.pop(0)
         self.last_interaction = time.time()
+
+    def _toggle_pause(self):
+        pause_file = Path("autotrain.pause")
+        if not self.paused:
+            pause_file.write_text("1")
+            self.paused_since = time.time()
+            self.paused = True
+            self.log_msg = "Paused autotrain"
+        else:
+            pause_file.unlink(missing_ok=True)
+            if self.paused_since:
+                self.paused_total += time.time() - self.paused_since
+            self.paused_since = None
+            self.paused = False
+            self.log_msg = "Resumed autotrain"
+
+    def _save_snapshot(self):
+        path = Path("logs/memory_backup.json")
+        path.parent.mkdir(exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(self.memory.data, f, indent=2)
+        self.flash_until = time.time() + 2
+        self.log_msg = "Snapshot saved"
+
+    def _manual_search(self):
+        if self.interactions:
+            query = self.interactions[-1][0]
+            web_search(query)
+            self.log_msg = f"Search triggered for: {query[:30]}"
+
+    def _clear_activity(self):
+        self.interactions = []
+        self.log_msg = "Activity cleared"
 
     def _color(self, score: float) -> int:
         if score >= 0.75:
@@ -75,9 +115,15 @@ class TerminalDashboard(threading.Thread):
             learning_rate = total / ((time.time() - self.start_time) / 60 + 1e-6)
             active = self.memory.data[-1]["source"] if self.memory.data else "N/A"
 
-            stdscr.addstr(0, 0, "=== JARVIS Console ===", curses.A_BOLD)
+            mode = "Paused" if self.paused else "Active"
+            if self.paused:
+                elapsed = int(time.time() - (self.paused_since or time.time()))
+                mode += f" ({elapsed}s)"
 
-            row = 2
+            stdscr.addstr(0, 0, "=== JARVIS Console ===", curses.A_BOLD)
+            stdscr.addstr(1, 0, f"Status: {mode}")
+
+            row = 3
             stdscr.addstr(row, 0, "Learning", curses.A_UNDERLINE)
             row += 1
             stdscr.addstr(row, 2, f"Success: {self.success}", curses.color_pair(1))
@@ -137,20 +183,29 @@ class TerminalDashboard(threading.Thread):
             else:
                 stdscr.addstr(row, 0, " " * 20)
 
-            stdscr.addstr(row + 2, 0, "Commands: [p]ause/[r]esume [c]lear [q]uit")
+            max_y, max_x = stdscr.getmaxyx()
+            controls = "[p] pause/resume  [m] snapshot  [r] search  [c] clear log  [q] quit"
+            stdscr.addstr(max_y - 3, 0, controls[: max_x - 1])
+            attr = curses.A_REVERSE if self.flash_until > time.time() else curses.A_DIM
+            stdscr.addstr(max_y - 2, 0, self.log_msg[: max_x - 1], attr)
             stdscr.refresh()
 
             ch = stdscr.getch()
             if ch != -1:
-                ch = chr(ch)
+                try:
+                    ch = chr(ch)
+                except ValueError:
+                    ch = ""
                 if ch == "p":
-                    self.paused = True
+                    self._toggle_pause()
+                elif ch == "m":
+                    self._save_snapshot()
                 elif ch == "r":
-                    self.paused = False
+                    self._manual_search()
                 elif ch == "c":
-                    self.memory.data = []
-                    self.memory.save()
+                    self._clear_activity()
                 elif ch == "q":
+                    self.log_msg = "Dashboard closed"
                     self.stop_event.set()
                     break
             time.sleep(self.refresh)


### PR DESCRIPTION
## Summary
- implement pause flag in `autotrain.py` so training can be suspended
- extend `TerminalDashboard` with keyboard shortcuts
- show active/paused status and log messages
- allow saving memory snapshots and manual web search

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853abb30750832ba61b4d9ea0756955