### PR TITLE
Add 3D and fluid visualization support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ sympy
 PySpice
 opencv-python
 networkx
+plotly
+kaleido
+bpy


### PR DESCRIPTION
## Summary
- support optional Blender/Plotly imports for visualizations
- add directories for saved GLB models
- create 3D beam models with Blender when simulating mechanical systems
- generate fluid flow heatmaps with Matplotlib or Plotly
- store optional GLB model path and expose it in simulation results
- list new dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bbf1eca8832bb8de5c619ed360ab