### PR TITLE
Add 3D model viewer to Streamlit dashboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ networkx
 plotly
 kaleido
 bpy
+streamlit==1.32.2


### PR DESCRIPTION
## Summary
- embed interactive 3D viewer for GLB models in `web_dashboard.py`
- show last 3D model and display models for each simulation
- add `streamlit` to requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853bd74a004832b8c1f9ea3d4c3bef9