### PR TITLE
Add advanced Tkinter dashboard

### DIFF
--- a/backend/gui_dashboard.py
+++ b/backend/gui_dashboard.py
@@ -1,27 +1,105 @@
+import json
+import os
+import time
 import tkinter as tk
-from utils.memory import MemoryManager
+from tkinter import ttk
 
 
-def build_gui():
-    mem = MemoryManager()
-    root = tk.Tk()
-    root.title("JARVIS Dashboard")
-    text = tk.Text(root, width=60, height=20)
-    text.pack()
-    for ticker, info in mem.memory.items():
-        if ticker in ("stats", "cooldowns"):
-            continue
-        text.insert(tk.END, f"{ticker}: {info['total_profit']:.2f} P/L\n")
-    stats = mem.memory.get("stats", {})
-    if stats:
-        wins = stats.get('wins',0)
-        losses = stats.get('losses',0)
-        total = wins+losses
-        if total:
-            win_rate = wins/total*100
-            text.insert(tk.END, f"Win rate: {win_rate:.2f}%\n")
-    root.mainloop()
+DATA_PATH = "data/strategy_stats.json"
+MEMORY_PATH = "data/memory.json"
+
+
+class JarvisGUI(tk.Tk):
+    """Simple dashboard showing recent memories and strategy stats."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("JARVIS Command Center")
+        self.geometry("800x600")
+        self.configure(bg="#121212")
+
+        title = tk.Label(
+            self,
+            text="JARVIS CORE DASHBOARD",
+            font=("Helvetica", 20),
+            fg="white",
+            bg="#121212",
+        )
+        title.pack(pady=10)
+
+        self.memory_frame = self._create_section("Top Memories")
+        self.strategy_frame = self._create_section("Strategy Stats")
+
+        self.refresh_btn = ttk.Button(self, text="\N{CLOCKWISE OPEN CIRCLE ARROW} Refresh", command=self.load_data)
+        self.refresh_btn.pack(pady=10)
+
+        self.load_data()
+
+    def _create_section(self, title: str) -> tk.LabelFrame:
+        frame = tk.LabelFrame(
+            self,
+            text=title,
+            bg="#1e1e1e",
+            fg="white",
+            font=("Helvetica", 14),
+            bd=2,
+        )
+        frame.pack(fill="both", expand=True, padx=10, pady=10)
+        frame.listbox = tk.Listbox(frame, font=("Consolas", 12), height=10, bg="#222", fg="lime")
+        frame.listbox.pack(fill="both", expand=True, padx=10, pady=10)
+        return frame
+
+    def _format_timestamp(self, ts: float | str) -> str:
+        try:
+            ts_f = float(ts)
+            return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(ts_f))
+        except Exception:
+            return str(ts)
+
+    def load_data(self) -> None:
+        """Refresh listboxes with data from disk."""
+        self.memory_frame.listbox.delete(0, tk.END)
+        self.strategy_frame.listbox.delete(0, tk.END)
+
+        # Load memories
+        if os.path.exists(MEMORY_PATH):
+            try:
+                with open(MEMORY_PATH, "r") as f:
+                    memories = json.load(f)
+            except Exception:
+                memories = []
+            top_memories: list[dict] = []
+            if isinstance(memories, list):
+                top_memories = sorted(memories, key=lambda m: m.get("importance", 1), reverse=True)[:5]
+            elif isinstance(memories, dict):
+                for ticker, info in memories.items():
+                    if ticker in {"stats", "cooldowns"}:
+                        continue
+                    top_memories.append({"timestamp": ticker, "event": f"{info.get('total_profit', 0.0):.2f} P/L"})
+                top_memories = top_memories[:5]
+            for mem in top_memories:
+                ts = self._format_timestamp(mem.get("timestamp"))
+                event = mem.get("event", "")
+                self.memory_frame.listbox.insert(tk.END, f"{ts} — {event}")
+
+        # Load strategy stats
+        if os.path.exists(DATA_PATH):
+            try:
+                with open(DATA_PATH, "r") as f:
+                    stats = json.load(f)
+            except Exception:
+                stats = {}
+            if isinstance(stats, dict):
+                for strat, data in stats.items():
+                    wins = data.get("wins", 0)
+                    losses = data.get("losses", 0)
+                    pnl = data.get("pnl", 0.0)
+                    self.strategy_frame.listbox.insert(
+                        tk.END,
+                        f"{strat}: W {wins}, L {losses}, PnL ${pnl:.2f}",
+                    )
 
 
 if __name__ == "__main__":
-    build_gui()
+    app = JarvisGUI()
+    app.mainloop()

--- a/data/strategy_stats.json
+++ b/data/strategy_stats.json
@@ -1,0 +1,1 @@
+{"baseline": {"wins": 0, "losses": 0, "pnl": 0.0}}


### PR DESCRIPTION
## Summary
- overhaul `gui_dashboard.py` with a class based Tkinter app
- display top memories and strategy stats from json files
- add example `strategy_stats.json`

## Testing
- `python -m py_compile backend/gui_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_6854a2f4adb0832ba16e00cf67a02e0f