### PR TITLE
Add modular AI dashboard

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+  "theme": "dark",
+  "default_strategy": "RSI",
+  "auto_mode": true,
+  "model": "mistral"
+}
+

--- a/gui/handlers/ai_handler.py
+++ b/gui/handlers/ai_handler.py
@@ -1,0 +1,31 @@
+import subprocess
+import requests
+from typing import Optional
+
+
+MODEL = "mistral"
+ENDPOINT = "http://localhost:11434/api/generate"
+
+
+def ask_ai(prompt: str) -> str:
+    payload = {"model": MODEL, "prompt": prompt, "stream": False}
+    try:
+        resp = requests.post(ENDPOINT, json=payload, timeout=30)
+        if resp.status_code == 200:
+            data = resp.json()
+            if isinstance(data, dict):
+                return data.get("response", "").strip()
+    except Exception:
+        pass
+    try:
+        result = subprocess.run([
+            "ollama",
+            "run",
+            MODEL,
+            prompt,
+        ], capture_output=True, text=True, timeout=30)
+        if result.stdout:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "Error: AI engine unavailable."

--- a/gui/handlers/memory_handler.py
+++ b/gui/handlers/memory_handler.py
@@ -1,0 +1,54 @@
+import json
+import os
+from typing import Any, List, Dict
+
+MEMORY_PATH = "data/memory.json"
+
+
+def load_memory() -> Any:
+    if os.path.exists(MEMORY_PATH):
+        try:
+            with open(MEMORY_PATH, "r") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
+
+
+def top_memories(n: int = 5) -> List[Dict[str, Any]]:
+    data = load_memory()
+    memories: List[Dict[str, Any]] = []
+    if isinstance(data, list):
+        memories = sorted(data, key=lambda m: m.get("importance", 1), reverse=True)[:n]
+    elif isinstance(data, dict):
+        for ticker, info in data.items():
+            if ticker in {"stats", "cooldowns"}:
+                continue
+            memories.append({"timestamp": ticker, "event": f"{info.get('total_profit', 0.0):.2f} P/L"})
+        memories = memories[:n]
+    return memories
+
+
+def search_memory(keyword: str = "", start: float | None = None, end: float | None = None) -> List[Dict[str, Any]]:
+    data = load_memory()
+    if not isinstance(data, list):
+        return []
+    results: List[Dict[str, Any]] = []
+    for mem in data:
+        ts = mem.get("timestamp")
+        event = mem.get("event", "")
+        if keyword and keyword.lower() not in event.lower():
+            continue
+        if start and ts < start:
+            continue
+        if end and ts > end:
+            continue
+        results.append(mem)
+    return results
+
+
+def export_memory(path: str = "memory_export.json") -> str:
+    data = load_memory()
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+    return path

--- a/gui/handlers/strategy_handler.py
+++ b/gui/handlers/strategy_handler.py
@@ -1,0 +1,33 @@
+import json
+import os
+from typing import Dict, List, Any
+
+DATA_PATH = "data/strategy_stats.json"
+STRATEGIES = ["RSI", "EMA", "MACD"]
+AUTO_MODE = True
+
+
+def load_stats() -> Dict[str, Any]:
+    if os.path.exists(DATA_PATH):
+        try:
+            with open(DATA_PATH, "r") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def pnl_history(strategy: str) -> List[float]:
+    stats = load_stats().get(strategy, {})
+    return stats.get("history", [])
+
+
+def toggle_auto() -> None:
+    global AUTO_MODE
+    AUTO_MODE = not AUTO_MODE
+
+
+def switch_strategy(current: str) -> str:
+    idx = STRATEGIES.index(current) if current in STRATEGIES else 0
+    idx = (idx + 1) % len(STRATEGIES)
+    return STRATEGIES[idx]


### PR DESCRIPTION
## Summary
- refactor `gui_dashboard.py` into modular UI using handlers
- add memory, strategy and AI handlers
- store user preferences in `config.json`

## Testing
- `python -m py_compile backend/gui_dashboard.py gui/handlers/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854a7322570832b850f7a8f5e48d563