### PR TITLE
Add Ollama training exporter and update model config

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,6 +2,6 @@
   "theme": "dark",
   "default_strategy": "RSI",
   "auto_mode": true,
-  "model": "mistral"
+  "model": "jarvisbrain"
 }
 

--- a/export_ollama_data.py
+++ b/export_ollama_data.py
@@ -1,0 +1,92 @@
+# Utility script to generate Ollama fine-tuning data from Jarvis logs
+import json
+from pathlib import Path
+
+
+def collect() -> list[dict]:
+    """Gather memory and audit logs into fine-tune messages."""
+    records: list[dict] = []
+
+    mem_path = Path("data/memory.json")
+    if mem_path.exists():
+        try:
+            data = json.loads(mem_path.read_text())
+            if isinstance(data, list):
+                for item in data:
+                    event = item.get("event")
+                    if event:
+                        records.append({
+                            "messages": [
+                                {"role": "system", "content": f"Memory: {event}"}
+                            ]
+                        })
+        except Exception:
+            pass
+
+    audit_dir = Path("logs/self_audit")
+    if audit_dir.exists():
+        for log in sorted(audit_dir.glob("*.json")):
+            try:
+                items = json.loads(log.read_text())
+                if isinstance(items, list):
+                    for entry in items:
+                        prompt = entry.get("prompt")
+                        resp = entry.get("response")
+                        if prompt and resp:
+                            records.append({
+                                "messages": [
+                                    {"role": "user", "content": prompt},
+                                    {"role": "assistant", "content": resp},
+                                ]
+                            })
+            except Exception:
+                continue
+
+    stats_path = Path("data/strategy_stats.json")
+    if stats_path.exists():
+        try:
+            stats = json.loads(stats_path.read_text())
+            for name, val in stats.items():
+                summary = (
+                    f"{name} strategy: wins {val.get('wins', 0)}, "
+                    f"losses {val.get('losses', 0)}, "
+                    f"pnl {val.get('pnl', 0.0)}"
+                )
+                records.append({
+                    "messages": [
+                        {"role": "system", "content": summary}
+                    ]
+                })
+        except Exception:
+            pass
+
+    qa_path = Path("data/qa_memory.json")
+    if qa_path.exists():
+        try:
+            qas = json.loads(qa_path.read_text())
+            if isinstance(qas, list):
+                for qa in qas:
+                    q = qa.get("question")
+                    a = qa.get("answer")
+                    if q and a:
+                        records.append({
+                            "messages": [
+                                {"role": "user", "content": q},
+                                {"role": "assistant", "content": a},
+                            ]
+                        })
+        except Exception:
+            pass
+
+    return records
+
+
+def main() -> None:
+    records = collect()
+    out = Path("training_data.jsonl")
+    out.write_text("\n".join(json.dumps(r) for r in records))
+    print(f"Wrote {len(records)} records to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gui/handlers/ai_handler.py
+++ b/gui/handlers/ai_handler.py
@@ -15,7 +15,8 @@ from .memory_handler import feedback_memories
 from .strategy_handler import load_stats, STRATEGIES
 
 
-MODEL = "mistral"
+# Local model name for Ollama. Replace with your fine-tuned model
+OLLAMA_MODEL = "jarvisbrain"
 ENDPOINT = "http://localhost:11434/api/generate"
 
 # history of user commands
@@ -63,7 +64,7 @@ def ask_ai(prompt: str) -> str:
     _LAST_CONTEXT = context
     background = json.dumps(context, indent=2)
     payload = {
-        "model": MODEL,
+        "model": OLLAMA_MODEL,
         "prompt": f"Context:\n{background}\n\nUser: {prompt}\nAI:",
         "stream": False,
     }
@@ -79,7 +80,7 @@ def ask_ai(prompt: str) -> str:
     if "Error" in response_text:
         try:
             result = subprocess.run(
-                ["ollama", "run", MODEL, payload["prompt"]],
+                ["ollama", "run", OLLAMA_MODEL, payload["prompt"]],
                 capture_output=True,
                 text=True,
                 timeout=30,


### PR DESCRIPTION
## Summary
- add `export_ollama_data.py` to create `training_data.jsonl` from logs
- change `OLLAMA_MODEL` constant in `ai_handler.py`
- set `model` in `config.json` to `jarvisbrain`

## Testing
- `pytest -q`
- `python -m py_compile export_ollama_data.py gui/handlers/ai_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_6854b09c06c4832b9efcad76f28e7ece