### PR TITLE
Integrate local Ollama finetuning

### DIFF
--- a/Modelfile
+++ b/Modelfile
@@ -1,0 +1,3 @@
+FROM mistral
+ADAPTER my-finetune
+SYSTEM "You are Felipe Ruiz's personal AI."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# JARVIS Local Training
+
+This repository fine-tunes an Ollama model using logs and memories from the JARVIS dashboard.
+
+1. Run the exporter to build a JSONL dataset:
+   ```bash
+   python3 export_ollama_data.py
+   ```
+   This creates `training_data.jsonl` in OpenAI chat format.
+
+2. Build the fine‑tuned model (requires Ollama installed):
+   ```bash
+   ollama create jarvisbrain -f Modelfile
+   ```
+
+The `Modelfile` uses the base `mistral` model and an adapter named `my-finetune`. The system message defines the assistant as **Felipe Ruiz's personal AI**.

--- a/backend/features/autotrade.py
+++ b/backend/features/autotrade.py
@@ -1,8 +1,6 @@
 # autotrade.py
 
 from dotenv import load_dotenv
-load_dotenv()
-
 import os
 from datetime import datetime
 import pandas as pd
@@ -11,6 +9,8 @@ from alpaca_trade_api import REST, TimeFrame
 from utils.memory import MemoryManager
 from .telegram_alerts import send_telegram_alert
 from .strategies import rsi_strategy, ema_strategy, macd_strategy
+
+load_dotenv()
 
 # === Load environment variables ===
 ALPACA_KEY = os.getenv("APCA_API_KEY_ID")

--- a/gui/handlers/ai_handler.py
+++ b/gui/handlers/ai_handler.py
@@ -8,15 +8,30 @@ import subprocess
 import requests
 import time
 from datetime import date
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Any
 
 from .memory_handler import top_memories, mark_used
 from .memory_handler import feedback_memories
 from .strategy_handler import load_stats, STRATEGIES
 
 
-# Local model name for Ollama. Replace with your fine-tuned model
-OLLAMA_MODEL = "jarvisbrain"
+CONFIG_PATH = "config.json"
+
+
+def _load_model() -> str:
+    """Return model name from config.json or default."""
+    if os.path.exists(CONFIG_PATH):
+        try:
+            with open(CONFIG_PATH, "r") as f:
+                data = json.load(f)
+                if isinstance(data, dict) and data.get("model"):
+                    return str(data["model"])
+        except Exception:
+            pass
+    return "jarvisbrain"
+
+
+OLLAMA_MODEL = _load_model()
 ENDPOINT = "http://localhost:11434/api/generate"
 
 # history of user commands

--- a/gui/handlers/memory_handler.py
+++ b/gui/handlers/memory_handler.py
@@ -1,7 +1,6 @@
 import json
 import os
 import time
-from datetime import datetime
 from typing import Any, List, Dict
 
 MEMORY_PATH = "data/memory.json"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ openai
 python-dotenv
 pandas
 tqdm
+matplotlib
+plotly
+ollama-python


### PR DESCRIPTION
## Summary
- load the ollama model name from `config.json`
- fix style errors flagged by ruff
- add a modelfile for fine-tuning
- document how to export logs and create the model
- include plotting and ollama libraries in requirements

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b2c84e64832ba8dfe9d478b806bd