### PR TITLE
Finalize Jarvis setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,28 @@ This repository fine-tunes an Ollama model using logs and memories from the JARV
    ```
 
 The `Modelfile` uses the base `mistral` model and an adapter named `my-finetune`. The system message defines the assistant as **Felipe Ruiz's personal AI**.
+
+## Setup on Felipe Ruiz's PC
+
+Follow these steps on a Windows machine to run the local JARVIS instance:
+
+1. **Install Ollama** – [Download](https://ollama.com/download) and install.
+2. **Pull the base model**:
+   ```bash
+   ollama pull mistral
+   ```
+3. **Run the fine-tune** in this repository directory:
+   ```bash
+   ollama create jarvisbrain -f Modelfile
+   ```
+4. **Launch JARVIS**:
+   ```bash
+   python backend/gui_dashboard.py
+   ```
+
+To preserve and improve the AI's memory, export logs and retrain monthly:
+
+```bash
+python export_ollama_data.py
+ollama create jarvisbrain -f Modelfile
+```

--- a/backend/gui_dashboard.py
+++ b/backend/gui_dashboard.py
@@ -1,9 +1,12 @@
 import json
 import os
 import time
+import sys
 import tkinter as tk
 from tkinter import messagebox, ttk
 from tkinter.scrolledtext import ScrolledText
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from gui.handlers.ai_handler import (
     ask_ai,

--- a/training_data.jsonl
+++ b/training_data.jsonl
@@ -1,0 +1,1 @@
+{"messages": [{"role": "system", "content": "baseline strategy: wins 0, losses 0, pnl 0.0"}]}


### PR DESCRIPTION
## Summary
- load the GUI modules properly by adding root to `sys.path`
- document Windows setup and monthly retraining steps
- include a small sample `training_data.jsonl` file

## Testing
- `ruff check .`
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`
- `python export_ollama_data.py`
- `python backend/gui_dashboard.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `ollama create jarvisbrain -f Modelfile` *(fails: command not found)*
- `ollama run jarvisbrain` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b47c2574832b928aa7acc78d1df0