### PR TITLE
Add streamlit chatbot dashboard

### DIFF
--- a/backend/gui_dashboard.py
+++ b/backend/gui_dashboard.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
+import time
 from pathlib import Path
 
 import streamlit as st
 
 from combined_jarvis import answer_question, load_memory, save_memory
 
-
 MEMORY_PATH = Path("memory.json")
 
-# Configure basic page settings for a clean layout
+# Responsive layout and basic page info
 st.set_page_config(page_title="JARVIS Chatbot", page_icon="🤖", layout="wide")
 
+# Hide Streamlit menu and footer, center chat messages
 st.markdown(
     """
     <style>
@@ -21,7 +24,7 @@ st.markdown(
     unsafe_allow_html=True,
 )
 
-# --- Sidebar ---
+# ----- Sidebar -----
 with st.sidebar:
     st.markdown("## 🤖 JARVIS")
     if st.button("New Chat", use_container_width=True):
@@ -32,30 +35,30 @@ with st.sidebar:
         st.write("Chat closed. You can now close this tab.")
         st.stop()
 
-
-# --- Load previous messages ---
+# ----- Load history -----
 if "messages" not in st.session_state:
     st.session_state.messages = []
     for record in load_memory():
         st.session_state.messages.append({"role": "user", "content": record.get("prompt", "")})
         st.session_state.messages.append({"role": "assistant", "content": record.get("response", "")})
 
-
-# --- Display chat history ---
+# ----- Display history -----
 for msg in st.session_state.messages:
     with st.chat_message(msg["role"]):
         st.markdown(msg["content"])
 
-
-# --- Prompt input ---
+# ----- User input -----
 if prompt := st.chat_input("Type your message and press Enter"):
     st.session_state.messages.append({"role": "user", "content": prompt})
     with st.chat_message("user"):
         st.markdown(prompt)
+
     with st.chat_message("assistant"):
         with st.spinner("Thinking..."):
             response = answer_question(prompt)
         st.markdown(response)
     st.session_state.messages.append({"role": "assistant", "content": response})
 
-
+    history = load_memory()
+    history.append({"prompt": prompt, "response": response, "timestamp": time.time()})
+    save_memory(history)


### PR DESCRIPTION
## Summary
- create a Streamlit dashboard using local models
- load prior chat history from `memory.json`
- store new prompts and responses back to `memory.json`

## Testing
- `python -m py_compile backend/gui_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68562661e198832b988614a46299ccf1