### PR TITLE
Add Streamlit GUI with engineering expert

### DIFF
--- a/backend/gui_dashboard.py
+++ b/backend/gui_dashboard.py
@@ -1,13 +1,16 @@
-from pathlib import Path
+from __future__ import annotations
 
+import json
+from pathlib import Path
 import streamlit as st
 
-from combined_jarvis import answer_question, load_memory, save_memory
-
+from combined_jarvis import answer_question, add_memory, load_memory, save_memory
+from features.engineering_expert import EngineeringExpert
 
 MEMORY_PATH = Path("memory.json")
+UPLOAD_DIR = Path("uploads")
+UPLOAD_DIR.mkdir(exist_ok=True)
 
-# Configure basic page settings for a clean layout
 st.set_page_config(page_title="JARVIS Chatbot", page_icon="🤖", layout="wide")
 
 st.markdown(
@@ -31,7 +34,23 @@ with st.sidebar:
     if st.button("Exit", use_container_width=True):
         st.write("Chat closed. You can now close this tab.")
         st.stop()
-
+    uploaded = st.file_uploader("Upload worksheet (.pdf or .txt)", type=["pdf", "txt"])
+    if uploaded:
+        file_path = UPLOAD_DIR / uploaded.name
+        file_path.write_bytes(uploaded.getvalue())
+        expert = st.session_state.get("expert", EngineeringExpert())
+        st.session_state.expert = expert
+        if file_path.suffix.lower() == ".pdf":
+            with st.spinner("Solving worksheet..."):
+                results = expert.solve_pdf_worksheet(str(file_path))
+            for q, sol in results.items():
+                st.markdown(f"**{q}**")
+                st.markdown(sol)
+        else:
+            content = file_path.read_text()
+            with st.spinner("Solving..."):
+                answer = expert.answer(content)
+            st.markdown(answer)
 
 # --- Load previous messages ---
 if "messages" not in st.session_state:
@@ -40,12 +59,13 @@ if "messages" not in st.session_state:
         st.session_state.messages.append({"role": "user", "content": record.get("prompt", "")})
         st.session_state.messages.append({"role": "assistant", "content": record.get("response", "")})
 
-
 # --- Display chat history ---
 for msg in st.session_state.messages:
     with st.chat_message(msg["role"]):
         st.markdown(msg["content"])
 
+expert = st.session_state.get("expert", EngineeringExpert())
+st.session_state.expert = expert
 
 # --- Prompt input ---
 if prompt := st.chat_input("Type your message and press Enter"):
@@ -54,8 +74,10 @@ if prompt := st.chat_input("Type your message and press Enter"):
         st.markdown(prompt)
     with st.chat_message("assistant"):
         with st.spinner("Thinking..."):
-            response = answer_question(prompt)
+            if EngineeringExpert.is_engineering_question(prompt):
+                response = expert.answer(prompt)
+            else:
+                response = answer_question(prompt)
         st.markdown(response)
     st.session_state.messages.append({"role": "assistant", "content": response})
-
-
+    add_memory(prompt, response)


### PR DESCRIPTION
## Summary
- overhaul `backend/gui_dashboard.py`
- add Streamlit chat UI with custom CSS and sidebar
- integrate `EngineeringExpert` for uploaded math/engineering files
- route engineering questions to the expert and store chat history

## Testing
- `python3 -m py_compile backend/gui_dashboard.py`
- `streamlit --version`

------
https://chatgpt.com/codex/tasks/task_e_685627919f34832b82e77fab84ecd72c