### PR TITLE
Fix import path in Streamlit dashboard

### DIFF
--- a/backend/gui_dashboard.py
+++ b/backend/gui_dashboard.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import streamlit as st
+import sys
 
-from combined_jarvis import answer_question, add_memory, load_memory, save_memory
-from features.engineering_expert import EngineeringExpert
+sys.path.append("..")
+from combined_jarvis import (
+    answer_question,
+    add_memory,
+    load_memory,
+    save_memory,
+    EngineeringExpert,
+)
 
 MEMORY_PATH = Path("memory.json")
 UPLOAD_DIR = Path("uploads")


### PR DESCRIPTION
## Summary
- update `backend/gui_dashboard.py` to locate `combined_jarvis.py` from the parent directory
- import `EngineeringExpert` and helper functions from the combined file

## Testing
- `python -m py_compile backend/gui_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68562938f344832b8ad29c2c04d5de58