### PR TITLE
Fix path for combined_jarvis import

### DIFF
--- a/backend/gui_dashboard.py
+++ b/backend/gui_dashboard.py
@@ -4,8 +4,11 @@ import json
 from pathlib import Path
 import streamlit as st
 import sys
+import os
 
-sys.path.append("..")
+# Ensure parent directory is in sys.path to import combined_jarvis.py
+sys.path.insert(0, os.path.abspath(Path(__file__).parent.parent))
+
 from combined_jarvis import (
     answer_question,
     add_memory,


### PR DESCRIPTION
## Summary
- ensure `gui_dashboard.py` adds the repo root to `sys.path` before importing `combined_jarvis`

## Testing
- `streamlit run backend/gui_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68562c0fff14832bb4f176c1ff2ecc85