### PR TITLE
Enable engineering solves and 3D model rendering

### DIFF
--- a/backend/features/engineering_expert.py
+++ b/backend/features/engineering_expert.py
@@ -122,6 +122,29 @@ class EngineeringExpert:
         self.formula_index = MemoryManager(path="data/formula_index.json")
         self.sim_index = MemoryManager(path="data/simulation_index.json")
 
+    def solve(self, prompt: str) -> str:
+        """Solve basic engineering formulas symbolically."""
+        from sympy import symbols, simplify, latex
+        import re
+
+        if "moment of inertia" in prompt.lower():
+            m, L = symbols("m L")
+            inertia = simplify((1 / 12) * m * L ** 2)
+            return f"The moment of inertia formula is:\n\nI = {latex(inertia)}"
+
+        return "I'm working on solving that. Try asking for a specific engineering formula."
+
+    def generate_beam_model(
+        self, length_m: float, width_m: float = 0.1, height_m: float = 0.1
+    ) -> str:
+        """Create a basic 3D beam model and export as GLB using trimesh."""
+        import trimesh
+
+        model = trimesh.creation.box(extents=[length_m, width_m, height_m])
+        out_path = os.path.join(MODEL_DIR, "beam_model.glb")
+        model.export(out_path)
+        return out_path
+
     def _index_formula(self, formula: str, tags: List[str], steps: str) -> None:
         entry = {
             "formula": formula,

--- a/backend/gui_dashboard.py
+++ b/backend/gui_dashboard.py
@@ -98,6 +98,18 @@ if prompt := st.chat_input("Type your message and press Enter"):
                 response = expert.answer(prompt)
             else:
                 response = answer_question(prompt)
-        st.markdown(response)
+
+        if response.strip().endswith(".glb"):
+            model_path = response.strip().split(":")[-1].strip()
+            st.markdown("### 3D Model Viewer:")
+            st.components.v1.html(
+                f'''
+        <model-viewer src="/{model_path}" alt="3D model" auto-rotate camera-controls style="width:100%; height:500px;"></model-viewer>
+        <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
+        ''',
+                height=500,
+            )
+        else:
+            st.markdown(response)
     st.session_state.messages.append({"role": "assistant", "content": response})
     add_memory(prompt, response)

--- a/combined_jarvis.py
+++ b/combined_jarvis.py
@@ -80,6 +80,35 @@ def answer_question(question: str) -> str:
     """Return an answer using web search and Ollama with fallbacks."""
     lower = question.lower()
 
+    # route engineering or 3d modeling prompts to the expert
+    if any(
+        kw in lower
+        for kw in [
+            "moment of inertia",
+            "beam",
+            "load",
+            "stress",
+            "strain",
+            "symbolic",
+            "blueprint",
+            "calculate",
+            "render 3d",
+        ]
+    ):
+        if "render" in lower and "3d" in lower:
+            try:
+                import re
+
+                length = float(re.search(r"(\d+\.?\d*)m", question).group(1))
+                model_path = engineering_expert.generate_beam_model(length)
+                return f"3D beam model generated: {model_path}"
+            except Exception:
+                return (
+                    "Could not parse beam length. Please say something like 'render 3D model of beam 10m long'."
+                )
+        else:
+            return engineering_expert.solve(question)
+
     # handle direct date requests instead of the old fixed answer
     date_triggers = (
         "current date",


### PR DESCRIPTION
## Summary
- route engineering prompts through `engineering_expert` in `combined_jarvis.py`
- support symbolic solves and beam model generation in `engineering_expert`
- display `.glb` responses using `<model-viewer>` in the Streamlit dashboard

## Testing
- `python -m py_compile combined_jarvis.py backend/features/engineering_expert.py backend/gui_dashboard.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856351544a8832ba7aa813e227b778f